### PR TITLE
LF-34618 Qt dashed line drawing.

### DIFF
--- a/src/gui/painting/qcosmeticstroker.cpp
+++ b/src/gui/painting/qcosmeticstroker.cpp
@@ -41,6 +41,7 @@
 #include "private/qpainterpath_p.h"
 #include "private/qrgba64_p.h"
 #include <qdebug.h>
+#include <QtCore/qmath.h>
 
 QT_BEGIN_NAMESPACE
 

--- a/src/gui/painting/qcosmeticstroker.cpp
+++ b/src/gui/painting/qcosmeticstroker.cpp
@@ -1148,7 +1148,7 @@ static bool drawLineAA(QCosmeticStroker *stroker, qreal rx1, qreal ry1, qreal rx
     return true;
 }
 
-static int calulateDashOffset(qreal major1, qreal major2, qreal minor1, qreal minor2)
+static int calculateDashOffset(qreal major1, qreal major2, qreal minor1, qreal minor2)
 {
     return toF26Dot6(qSqrt((major2 - major1) * (major2 - major1) + (minor2 - minor1) * (minor2 - minor1)));
 }
@@ -1186,9 +1186,9 @@ static bool drawLineAAFixed(QCosmeticStroker *stroker, qreal rx1, qreal ry1, qre
             qSwap(x1, x2);
             swapped = true;
             caps = swapCaps(caps);
-            offset = calulateDashOffset(oldy1, ry2, oldx1, rx2);
+            offset = calculateDashOffset(oldy1, ry2, oldx1, rx2);
         } else
-            offset = calulateDashOffset(oldy1, ry1, oldx1, rx1);
+            offset = calculateDashOffset(oldy1, ry1, oldx1, rx1);
 
         int x = (x1 - 32) * (1 << 10);
         x -= (((y1 & 63) - 32) * xinc) >> 6;
@@ -1252,9 +1252,9 @@ static bool drawLineAAFixed(QCosmeticStroker *stroker, qreal rx1, qreal ry1, qre
             qSwap(y1, y2);
             swapped = true;
             caps = swapCaps(caps);
-            offset = calulateDashOffset(oldx1, rx2, oldy1, ry2);
+            offset = calculateDashOffset(oldx1, rx2, oldy1, ry2);
         } else
-            offset = calulateDashOffset(oldx1, rx1, oldy1, ry1);
+            offset = calculateDashOffset(oldx1, rx1, oldy1, ry1);
 
         int y = (y1 - 32) * (1 << 10);
         y -= (((x1 & 63) - 32) * yinc) >> 6;

--- a/src/gui/painting/qcosmeticstroker.cpp
+++ b/src/gui/painting/qcosmeticstroker.cpp
@@ -1150,10 +1150,7 @@ static bool drawLineAA(QCosmeticStroker *stroker, qreal rx1, qreal ry1, qreal rx
 
 static int calulateDashOffset(qreal major1, qreal major2, qreal minor1, qreal minor2)
 {
-    qreal offset =
-            qSqrt((major2 - major1) * (major2 - major1) + (minor2 - minor1) * (minor2 - minor1));
-    // qDebug() << "Offset: " << offset << " Points: " << major1 << major2 << minor1 << minor2;
-    return toF26Dot6(offset);
+    return toF26Dot6(qSqrt((major2 - major1) * (major2 - major1) + (minor2 - minor1) * (minor2 - minor1)));
 }
 
 template<DrawPixel drawPixel>
@@ -1192,12 +1189,6 @@ static bool drawLineAAFixed(QCosmeticStroker *stroker, qreal rx1, qreal ry1, qre
             offset = calulateDashOffset(oldy1, ry2, oldx1, rx2);
         } else
             offset = calulateDashOffset(oldy1, ry1, oldx1, rx1);
-
-        // qDebug() << "Offset: " << offset << " Unclipped: " << oldx1 << oldy1 << oldx2 << oldy2
-        //         << " Clipped: " << rx1 << ry1 << rx2 << ry2 << "xInc" << xinc;
-
-        // offset -= (64 * (32 - (y1 & 63)) + (xinc >> 10) * (32 - (x1 & 63))) / qSqrt(64 * 64 + (xinc >> 10) * (xinc >> 10));
-        // qDebug() << "Offset: " << offset << x1 << y1 << (32 - (x1 & 63)) << (32 - (y1 & 63)) <<  (xinc >> 10) << qSqrt(64 * 64 + (xinc >> 10) * (xinc >> 10));
 
         int x = (x1 - 32) * (1 << 10);
         x -= (((y1 & 63) - 32) * xinc) >> 6;
@@ -1265,11 +1256,6 @@ static bool drawLineAAFixed(QCosmeticStroker *stroker, qreal rx1, qreal ry1, qre
         } else
             offset = calulateDashOffset(oldx1, rx1, oldy1, ry1);
 
-        // qDebug() << "Offset: " << offset << " Unclipped: " << oldx1 << oldy1 << oldx2 << oldy2
-        //        << " Clipped: " << rx1 << ry1 << rx2 << ry2 << "yInc" << yinc;
-
-        // offset -= (64 * (32 - (x1 & 63)) + (yinc >> 10) * (32 - (y1 & 63))) / qSqrt(64 * 64 + (yinc >> 10) * (yinc >> 10));
-        // qDebug() << "Offset: " << offset << x1 << y1 << (32 - (x1 & 63)) << (32 - (y1 & 63)) <<  (yinc >> 10) << qSqrt(64 * 64 + (yinc >> 10) * (yinc >> 10));
         int y = (y1 - 32) * (1 << 10);
         y -= (((x1 & 63) - 32) * yinc) >> 6;
 

--- a/src/gui/painting/qpaintengine_raster.cpp
+++ b/src/gui/painting/qpaintengine_raster.cpp
@@ -1663,7 +1663,7 @@ void QRasterPaintEngine::stroke(const QVectorPath &path, const QPen &pen)
     ensurePen(pen);
     if (!s->penData.blend)
         return;
-
+    
     if (s->flags.fast_pen) {
         QCosmeticStroker stroker(s, d->deviceRect, d->deviceRectUnclipped);
         stroker.setLegacyRoundingEnabled(s->flags.legacy_rounding);

--- a/src/gui/painting/qpaintengine_raster.cpp
+++ b/src/gui/painting/qpaintengine_raster.cpp
@@ -1663,7 +1663,7 @@ void QRasterPaintEngine::stroke(const QVectorPath &path, const QPen &pen)
     ensurePen(pen);
     if (!s->penData.blend)
         return;
-    
+
     if (s->flags.fast_pen) {
         QCosmeticStroker stroker(s, d->deviceRect, d->deviceRectUnclipped);
         stroker.setLegacyRoundingEnabled(s->flags.legacy_rounding);

--- a/src/widgets/dialogs/qcolordialog.cpp
+++ b/src/widgets/dialogs/qcolordialog.cpp
@@ -1527,7 +1527,7 @@ void QColorDialogPrivate::setCurrentQColor(const QColor &color)
 // size of standard and custom color selector
 enum {
     colorColumns = 8,
-    standardColorRows = 6,
+    standardColorRows = 3,
     customColorRows = 2
 };
 
@@ -1603,7 +1603,7 @@ void QColorDialogPrivate::_q_newCustom(int r, int c)
 
 void QColorDialogPrivate::_q_newStandard(int r, int c)
 {
-    setCurrentRgbColor(QColorDialogOptions::standardColor(r + c * 6));
+    setCurrentRgbColor(QColorDialogOptions::standardColor(r + c * standardColorRows));
     if (custom)
         custom->setSelected(-1,-1);
 }


### PR DESCRIPTION
Improves dashed line drawing. This is only used when the render hint `0x80` is set, so will not affect anywhere else that doesn't explicitly set that render hint.