### PR TITLE
LF-36223 Fix rounding error within QBackingStore

### DIFF
--- a/src/gui/painting/qbackingstore.cpp
+++ b/src/gui/painting/qbackingstore.cpp
@@ -249,8 +249,11 @@ void QBackingStore::flush(const QRegion &region, QWindow *window, const QPoint &
 
     Q_ASSERT(window == topLevelWindow || topLevelWindow->isAncestorOf(window, QWindow::ExcludeTransients));
 
-    handle()->flush(window, QHighDpi::toNativeLocalRegion(region, window),
-                                            QHighDpi::toNativeLocalPosition(offset, window));
+    // Scale the region relative to the top level window, so it avoids rounding errors when both
+    // offset and region would round up if scaled independently.
+    QPoint nativeOffset = QHighDpi::toNativeLocalPosition(offset, window);
+    QRegion nativeRegion = QHighDpi::toNativeLocalRegion(region.translated(offset), window);
+    handle()->flush(window, nativeRegion.translated(-nativeOffset), nativeOffset);
 }
 
 /*!


### PR DESCRIPTION
As an example of the problem: on 175% scaling with an offset of 42px, and a region origin of 46px, they are scaled to become 74px(rounded up from 73.5) and 81px(rounded up from 80.5) respectively, so it will say the region will be 155px from the corner of the top-level window, where it should be 154px. With this fix, we scale 88px, which is the combined offset and region origin, which scales to become 154px exactly.