### PR TITLE
LF-34205 Fix scaling error in QColorDialog colour picker

### DIFF
--- a/src/widgets/dialogs/qcolordialog.cpp
+++ b/src/widgets/dialogs/qcolordialog.cpp
@@ -120,6 +120,7 @@ public:
     void setCurrentQColor(const QColor &color);
     bool selectColor(const QColor &color);
     QColor grabScreenColor(const QPoint &p);
+    QColor grabScreenColor(const QPoint &screen_point, QScreen *screen);
 
     int currentAlpha() const;
     void setCurrentAlpha(int a);
@@ -1571,8 +1572,30 @@ bool QColorDialogPrivate::selectColor(const QColor &col)
 
 QColor QColorDialogPrivate::grabScreenColor(const QPoint &p)
 {
-    const QDesktopWidget *desktop = QApplication::desktop();
-    const QPixmap pixmap = QGuiApplication::primaryScreen()->grabWindow(desktop->winId(), p.x(), p.y(), 1, 1);
+    // Get the screen at p if it exists.
+    QScreen *screen = QGuiApplication::screenAt(p);
+    QScreen *primary_screen = QGuiApplication::primaryScreen();
+
+    if (!screen || screen == primary_screen)
+        // If no screen found then use primary. Origin is (0,0) so no need to shift.
+        return grabScreenColor(p, primary_screen);
+
+    // Get the origin of the current screen
+    const QPoint origin = screen->geometry().topLeft();
+
+    // Convert the logical global point to a logical screen point.
+    const QPoint screen_p = p - origin;
+
+    // Use the shifted point to return the screen color
+    return grabScreenColor(screen_p, screen);
+}
+
+// Get the pixel color at the specified point p on the specified screen.
+// Use screen coordinates rather than global to get around scaling issues.
+QColor QColorDialogPrivate::grabScreenColor(const QPoint &p, QScreen *screen)
+{
+    // Get a 1x1 pixmap from the screen, id=0 refers to the screen.
+    const QPixmap pixmap = screen->grabWindow(0, p.x(), p.y(), 1, 1);
     QImage i = pixmap.toImage();
     return i.pixel(0, 0);
 }


### PR DESCRIPTION
Currently, the color picker is incorrect when used on monitors with a different dpi scaling to the primary monitor. The fix consists of refactoring to use screen co-ordinates rather than working out the complicated global coordinates.