### PR TITLE
LF-47343 Fix icon being pixelated on some buttons

### DIFF
--- a/src/widgets/styles/qstylesheetstyle.cpp
+++ b/src/widgets/styles/qstylesheetstyle.cpp
@@ -3564,7 +3564,7 @@ void QStyleSheetStyle::drawControl(ControlElement ce, const QStyleOption *opt, Q
                     if (button->state & State_On)
                         state = QIcon::On;
 
-                    QPixmap pixmap = icon.pixmap((qt_getWindow(w), button->iconSize, mode, state);
+                    QPixmap pixmap = icon.pixmap(qt_getWindow(w), button->iconSize, mode, state);
                     int pixmapWidth = pixmap.width() / pixmap.devicePixelRatio();
                     int pixmapHeight = pixmap.height() / pixmap.devicePixelRatio();
                     int labelWidth = pixmapWidth;

--- a/src/widgets/styles/qstylesheetstyle.cpp
+++ b/src/widgets/styles/qstylesheetstyle.cpp
@@ -125,6 +125,10 @@ QT_BEGIN_NAMESPACE
 
 using namespace QCss;
 
+static QWindow *qt_getWindow(const QWidget *widget)
+{
+    return widget ? widget->window()->windowHandle() : 0;
+}
 
 class QStyleSheetStylePrivate : public QWindowsStylePrivate
 {
@@ -3560,7 +3564,7 @@ void QStyleSheetStyle::drawControl(ControlElement ce, const QStyleOption *opt, Q
                     if (button->state & State_On)
                         state = QIcon::On;
 
-                    QPixmap pixmap = icon.pixmap(button->iconSize, mode, state);
+                    QPixmap pixmap = icon.pixmap((qt_getWindow(w), button->iconSize, mode, state);
                     int pixmapWidth = pixmap.width() / pixmap.devicePixelRatio();
                     int pixmapHeight = pixmap.height() / pixmap.devicePixelRatio();
                     int labelWidth = pixmapWidth;


### PR DESCRIPTION
I initially tried to fix this by modifying our own style class, but that wasn't feasible as QStyleSheetStyle doesn't delegate enough to the base style.