### PR TITLE
LF-52396: convert plain text to rich text for tooltips, as plain text…

### DIFF
--- a/src/gui/kernel/qaction.cpp
+++ b/src/gui/kernel/qaction.cpp
@@ -9,7 +9,6 @@
 #include "qevent.h"
 #include "qlist.h"
 #include "qstylehints.h"
-
 #if QT_CONFIG(shortcut)
 #  include <private/qshortcutmap_p.h>
 #endif

--- a/src/gui/kernel/qaction.cpp
+++ b/src/gui/kernel/qaction.cpp
@@ -9,11 +9,13 @@
 #include "qevent.h"
 #include "qlist.h"
 #include "qstylehints.h"
+
 #if QT_CONFIG(shortcut)
 #  include <private/qshortcutmap_p.h>
 #endif
 #include <private/qguiapplication_p.h>
 #include <private/qdebug_p.h>
+#include <text/qtextdocument.h>
 
 #define QAPP_CHECK(functionName) \
     if (Q_UNLIKELY(!QCoreApplication::instance())) { \
@@ -682,10 +684,20 @@ QString QAction::iconText() const
 void QAction::setToolTip(const QString &tooltip)
 {
     Q_D(QAction);
-    if (d->tooltip == tooltip)
+
+    // Plain text must be converted to rich text for the tooltip to wrap correctly
+    QString result = tooltip;
+    if (!Qt::mightBeRichText(result))
+    {
+        // Escape the current message as HTML and replace \n with <br>
+        // Envelop the string with <qt></qt> so it is detected as richtext
+        result = "<qt>" + result.toHtmlEscaped() + "</qt>";
+    }
+
+    if (d->tooltip == result)
         return;
 
-    d->tooltip = tooltip;
+    d->tooltip = result;
     d->sendDataChanged();
 }
 

--- a/src/widgets/kernel/qwidget.cpp
+++ b/src/widgets/kernel/qwidget.cpp
@@ -11604,7 +11604,20 @@ void QWidgetPrivate::setWindowModified_helper()
 void QWidget::setToolTip(const QString &s)
 {
     Q_D(QWidget);
-    d->toolTip = s;
+    
+    // Plain text must be converted to rich text for the tooltip to wrap correctly
+    QString result = s;
+    if (!Qt::mightBeRichText(result))
+    {
+        // Escape the current message as HTML and replace \n with <br>
+        // Envelop the string with <qt></qt> so it is detected as richtext
+        result = "<qt>" + result.toHtmlEscaped() + "</qt>";
+    }
+
+    if (d->toolTip == result)
+        return;
+
+    d->toolTip = result;
 
     QEvent event(QEvent::ToolTipChange);
     QCoreApplication::sendEvent(this, &event);


### PR DESCRIPTION
convert any plain text to rich text, to ensure it wrapped in tooltips

https://bugreports.qt.io/browse/QTBUG-41051

`QWidget::setTooltip` applies the wrapping to all widgets

`QAction::setTooltip` is also required, as some buttons are set as 'actions' it seems. (i.e. actions on a toolbar). There seems to be some inconsistent behavior with this, sometimes these actions did seem to be wrapped and other times not. 

`QGraphicsItem::setTooltip` -> considered adding the same behavior to this method, but wasn't sure exactly what it is affecting and if we are using it.

Please note that the wrapping is not constant, and seems to adapt based on your screen in some form